### PR TITLE
Various improvements to the project setup/structure

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 FLASK_ENV=development
 FLASK_DEBUG=1
-FLASK_APP=openreferee_server
+FLASK_APP=openreferee_server.server

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 FLASK_ENV=development
 FLASK_DEBUG=1
-FLASK_APP=openreferee_server.server
+FLASK_APP=openreferee_server.app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
             architecture: 'x64'
       - name: Generate OpenAPI spec from the application
         run: |
-          pip install -e .
+          pip install -e '.[dev]'
           npm ci
           cp specs/openreferee.yaml specs/openreferee.old.yaml
           npm run api-spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
             echo "::set-env name=GH_COMMENT_FILE::${COMMENT_FILE}"
             printf ":warning: There are differences between the generated spec and the app" > ${COMMENT_FILE}
             printf "\n\n\`\`\`diff\n" >> ${COMMENT_FILE}
-            cat ${{ env.DIFF_FILE }} >> ${GH_COMMENT_FILE }
-            printf "\n\`\`\`\n" >> ${GH_COMMENT_FILE }
+            cat ${{ env.DIFF_FILE }} >> ${COMMENT_FILE}
+            printf "\n\`\`\`\n" >> ${COMMENT_FILE}
           fi
       - name: comment PR
         if: ${{ env.GH_COMMENT_FILE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate OpenAPI spec from the application
         run: |
           pip install -e .
-          npm i .
+          npm ci
           cp specs/openreferee.yaml specs/openreferee.old.yaml
           npm run api-spec
       - name: Set up env variables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [master]
@@ -17,39 +13,22 @@ jobs:
     steps:
       - name: Check out PR branch
         uses: actions/checkout@v2
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-            python-version: '3.8'
-            architecture: 'x64'
+          python-version: '3.8'
+          architecture: 'x64'
+
       - name: Install dependencies
         run: |
           pip install -e '.[dev]'
           npm ci
+
       - name: Generate OpenAPI spec from the application
         run: |
           cp specs/openreferee.yaml specs/openreferee.old.yaml
           npm run api-spec
-      - name: Set up env variables
-        run:  |
-          echo "::set-env name=ORIGIN_SPEC::$(echo "$(pwd)/specs/openreferee.old.yaml" )"
-          echo "::set-env name=MODIFIED_SPEC::$(echo "$(pwd)/specs/openreferee.yaml" )"
-          echo "::set-env name=DIFF_FILE::$(echo "$(pwd)/openapi.diff" )"
-      - name: Generate report
-        run: |
-          if ! diff -u ${{ env.ORIGIN_SPEC }} ${{ env.MODIFIED_SPEC }} > ${{ env.DIFF_FILE }};
-          then
-            COMMENT_FILE=$(echo "$(pwd)/github-comment.md")
-            echo "::set-env name=GH_COMMENT_FILE::${COMMENT_FILE}"
-            printf ":warning: There are differences between the generated spec and the app" > ${COMMENT_FILE}
-            printf "\n\n\`\`\`diff\n" >> ${COMMENT_FILE}
-            cat ${{ env.DIFF_FILE }} >> ${COMMENT_FILE}
-            printf "\n\`\`\`\n" >> ${COMMENT_FILE}
-          fi
-      - name: comment PR
-        if: ${{ env.GH_COMMENT_FILE }}
-        uses: machine-learning-apps/pr-comment@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          path: github-comment.md
+
+      - name: Check OpenAPI spec for changes
+        run: diff --color -u specs/openreferee.old.yaml specs/openreferee.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   diff-openapi-spec:
@@ -22,10 +22,12 @@ jobs:
         with:
             python-version: '3.8'
             architecture: 'x64'
-      - name: Generate OpenAPI spec from the application
+      - name: Install dependencies
         run: |
           pip install -e '.[dev]'
           npm ci
+      - name: Generate OpenAPI spec from the application
+        run: |
           cp specs/openreferee.yaml specs/openreferee.old.yaml
           npm run api-spec
       - name: Set up env variables

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a reference implementation of the OpenReferee Specification.
 
 ### Development setup
 ```
-pip install -e .
-npm i
+pip install -e '.[dev]'
+npm ci
 ```
 
 ### Running Test Server

--- a/openreferee_server/__init__.py
+++ b/openreferee_server/__init__.py
@@ -1,13 +1,2 @@
-import configparser
-import os
-
-
-# read version from setup.cfg
-parser = configparser.ConfigParser()
-parser.read(os.path.join(os.path.dirname(__file__), "..", "setup.cfg"))
-
-__version__ = parser["metadata"]["version"]
-
-from .server import app  # noqa: E402, isort:skip
-
-__all__ = ["app", "__version__"]
+__version__ = "0.0.1"
+__all__ = ("__version__",)

--- a/openreferee_server/app.py
+++ b/openreferee_server/app.py
@@ -4,15 +4,20 @@ from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
 from flask import Flask, jsonify
-from flask_cors import CORS
 from werkzeug.exceptions import HTTPException, UnprocessableEntity
 
 from . import __version__
 
 
+try:
+    from flask_cors import CORS
+except ImportError:
+    CORS = None
+
+
 def create_app():
     app = Flask(__name__)
-    if os.environ.get("FLASK_ENABLE_CORS"):
+    if os.environ.get("FLASK_ENABLE_CORS") and CORS is not None:
         CORS(app)
     app.config["SQLALCHEMY_DATABASE_URI"] = "postgresql:///editingsvc"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False

--- a/openreferee_server/db.py
+++ b/openreferee_server/db.py
@@ -1,9 +1,7 @@
 from flask_sqlalchemy import SQLAlchemy
 
-from .app import app
 
-
-db = SQLAlchemy(app)
+db = SQLAlchemy()
 db.Model.metadata.naming_convention = {
     "fk": "fk_%(table_name)s_%(column_names)s_%(referred_table_name)s",
     "pk": "pk_%(table_name)s",

--- a/openreferee_server/schemas.py
+++ b/openreferee_server/schemas.py
@@ -4,20 +4,16 @@ from webargs import fields
 from .defaults import SERVICE_INFO
 
 
+class ListEndpointSchema(Schema):
+    create = fields.String(required=True)
+    list = fields.String(required=True)
+
+
 class EventEndpointsSchema(Schema):
-    tags = fields.Nested(
-        {"create": fields.String(required=True), "list": fields.String(required=True)}
-    )
+    tags = fields.Nested(ListEndpointSchema)
     editable_types = fields.String(required=True)
     file_types = fields.Dict(
-        keys=fields.String(),
-        values=fields.Nested(
-            {
-                "create": fields.String(required=True),
-                "list": fields.String(required=True),
-            }
-        ),
-        required=True,
+        keys=fields.String(), values=fields.Nested(ListEndpointSchema), required=True,
     )
 
 
@@ -28,14 +24,17 @@ class EventSchema(Schema):
     config_endpoints = fields.Nested(EventEndpointsSchema, required=True,)
 
 
+class EventInfoServiceSchema(Schema):
+    version = fields.String()
+    name = fields.String()
+
+
 class EventInfoSchema(Schema):
     title = fields.String(required=True)
     url = fields.URL(schemes={"http", "https"}, required=True)
     can_disconnect = fields.Boolean(required=True, default=True)
     service = fields.Nested(
-        {"version": fields.String(), "name": fields.String()},
-        required=True,
-        default=SERVICE_INFO,
+        EventInfoServiceSchema, required=True, default=SERVICE_INFO,
     )
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openreferee-refserver",
   "private": true,
   "scripts": {
-    "isort": "isort --recursive setup.py openreferee_server/",
+    "isort": "isort setup.py openreferee_server/",
     "black": "black setup.py openreferee_server/",
     "pycodestyle": "pycodestyle openreferee_server/",
     "flake8": "flake8 openreferee_server/",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "black": "black setup.py openreferee_server/",
     "pycodestyle": "pycodestyle openreferee_server/",
     "flake8": "flake8 openreferee_server/",
-    "api-spec": "flask openapi > specs/openreferee.yaml",
+    "api-spec": "flask openapi | sed -e :a -e '/^\\n*$/{$d;N;};/\\n$/ba' > specs/openreferee.yaml",
     "api-spec-test": "flask openapi --json --test -h localhost -p 12345 > specs/openreferee.test.json",
     "api-docs": "npm run api-spec && speccy serve specs/openreferee.yaml",
     "swagger-ui": "npm run api-spec-test && docker run -p 5001:8080 -e SWAGGER_JSON=/specs/openreferee.test.json -v $(pwd)/specs:/specs swaggerapi/swagger-ui"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,0 @@
-black
-isort
-flake8
-pycodestyle
-python-dotenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,14 @@
 [metadata]
 name = openreferee-reference-server
+version = attr: openreferee_server.__version__
 url = https://github.com/indico/openreferee
 author = Indico Team
 author_email = indico-team@cern.ch
-version = 0.0.1
 license = MIT
 description = OpenReferee Reference Server
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8; variant=CommonMark
+
 
 [options]
 packages = find:
@@ -16,17 +19,22 @@ install_requires =
   werkzeug
   flask
   flask-sqlalchemy
-  flask-cors
   requests
-  sqlalchemy
+  sqlalchemy[postgresql]
   webargs
   psycopg2
   apispec[yaml]
   apispec-webframeworks
 
-[pycodestyle]
-exclude=__pycache__
-max-line-length=89
+[options.extras_require]
+dev =
+  black
+  flake8
+  flask-cors
+  isort
+  python-dotenv
+  ipython
+  flask-shell-ipython
 
 [flake8]
 exclude=__pycache__

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
 from setuptools import setup
 
+
 setup()

--- a/specs/openreferee.yaml
+++ b/specs/openreferee.yaml
@@ -187,4 +187,3 @@ tags:
 - name: info
 - name: remove
 - name: service
-

--- a/specs/openreferee.yaml
+++ b/specs/openreferee.yaml
@@ -23,10 +23,10 @@ components:
           type: string
         file_types:
           additionalProperties:
-            $ref: '#/components/schemas/Generated'
+            $ref: '#/components/schemas/ListEndpoint'
           type: object
         tags:
-          $ref: '#/components/schemas/Generated1'
+          $ref: '#/components/schemas/ListEndpoint'
       required:
       - editable_types
       - file_types
@@ -36,7 +36,7 @@ components:
         can_disconnect:
           type: boolean
         service:
-          $ref: '#/components/schemas/Generated2'
+          $ref: '#/components/schemas/EventInfoService'
         title:
           type: string
         url:
@@ -48,32 +48,22 @@ components:
       - title
       - url
       type: object
-    Generated:
-      properties:
-        create:
-          type: string
-        list:
-          type: string
-      required:
-      - create
-      - list
-      type: object
-    Generated1:
-      properties:
-        create:
-          type: string
-        list:
-          type: string
-      required:
-      - create
-      - list
-      type: object
-    Generated2:
+    EventInfoService:
       properties:
         name:
           type: string
         version:
           type: string
+      type: object
+    ListEndpoint:
+      properties:
+        create:
+          type: string
+        list:
+          type: string
+      required:
+      - create
+      - list
       type: object
     ServiceInfo:
       properties:


### PR DESCRIPTION
- ~~simplify isort config (use black profile)~~ (vscode bundles isort 4 which doesn't support profiles)
- use [dev] setuptools extra for dev dependencies
- `npm ci` to install JS deps
- use `__init__.py` as version source of truth (setup.cfg is not available after installing a package)
- remove unnecessary pycodestyle config (flake8 is enough)
- avoid 'Generated' schema names
- use app factory pattern without importable `app` instance